### PR TITLE
Bump the lambda runtime version to  3.9

### DIFF
--- a/lambda.tf
+++ b/lambda.tf
@@ -7,7 +7,7 @@ resource "aws_lambda_function" "sns_to_sentry" {
   function_name = "${var.name}-sns-to-sentry"
   handler       = "sns_to_sentry.lambda_handler.sns_to_sentry"
   role          = aws_iam_role.sns_to_sentry.arn
-  runtime       = "python3.7"
+  runtime       = "python3.9"
 
   timeout     = 300
   memory_size = 128


### PR DESCRIPTION
Please update the Python lambda runtime version to the one which is supported to fix `terraform apply`  errors like this:

```
Error: error creating Lambda Function (1): InvalidParameterValueException: The runtime parameter of python3.7 is no longer supported for creating or updating AWS Lambda functions. We recommend you use the new runtime (python3.12) while creating or updating functions.
│ {
│   RespMetadata: {
│     StatusCode: 400,
│     RequestID: "2e8b1892-b977-419c-b6bf-b72a0b143cf8"
│   },
│   Message_: "The runtime parameter of python3.7 is no longer supported for creating or updating AWS Lambda functions. We recommend you use the new runtime (python3.12) while creating or updating functions.",
│   Type: "User"
│ }
│ 
